### PR TITLE
Update interrupt handling, fix `white`, and setup PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ python:
 cache:
   pip: true
 
-# TODO: if deployment to PyPi is desired, change 'DEPLOY_PYPI' to "true",
-#       or remove the env block entirely and remove the condition in the
-#       deploy block.
 env:
   - DEPLOY_PYPI="false"
 
@@ -31,7 +28,7 @@ deploy:
   - provider: pypi
     user: adafruit-travis
     password:
-      secure: #-- PASTE ENCRYPTED PASSWORD HERE --#
+      secure: J/BVp5vHcmjpKFVmYCL0NoUqbk/TLwq1VtpF+EEvpzV+xEAelnwbnv49I27gUsRZH/mfBZi2KO+cTdVXAWCchXAo7QuPyHSnXdHLhmYmO5qRuClAE7Jyn8lYoScPpXhxV9jXg0kpq1CW1xetqxepPOqkT1+i+mL+Cb+2XurXv9kWSE+kzIdGIAAwbxPlgEPnUuNHCAjGBfzEWoCAk3BRT/31sfJ7K87awIcrYeOSxyl4H+uqCXRw5KvaleiW7sSu5Dgl+uwKUXnir/Nwm7eyrfF4N38Yf7sMmqiZxSMFrTsK9aDtr4NFfJvgKfXHKcdqdBXKFplOE7qILG/4WBSCXwO1Gep+sd2aQB6TJCg73Y/vh4skutIgigYKbqkZ7kZ8mFTlFxxRT1pTDf2qbcxUkwwjBGWQO9ORj8q8wwXQAMfMk5bxTgz3Vtqzbk0fruU2TswZu+LrgsLrVOh/gqBb302yiLhI9RzH+06M60JD59M0h1KvLIqJmaYI2oT2oguWpqnNeHLzC+yNx4IRe3IGrK2XF/OVzm9DzIAkgrCguZWq2ksx+RfTtwmRX0wtgUdpy+nCZDGDpWmG/xrC5PaMRTlA8QVK0dETjGs3wXxGxQyM8rjnxJ324+8LfrvT8/m8/AEjXQM/Y9Cv3sHI1hLW9UMPa8fLQFzuuAbNQuuV3Eo=
     on:
       tags: true
       condition: $DEPLOY_PYPI = "true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   pip: true
 
 env:
-  - DEPLOY_PYPI="false"
+  - DEPLOY_PYPI="true"
 
 deploy:
   - provider: releases

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,6 @@ This is easily achieved by downloading
 
 Installing from PyPI
 --------------------
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-vcnl4040/>`_. To install for current user:

--- a/adafruit_vcnl4040.py
+++ b/adafruit_vcnl4040.py
@@ -291,11 +291,8 @@ class VCNL4040:  # pylint: disable=too-few-public-methods
     def _update_interrupt_state(self):
         interrupts = [self.PS_IF_AWAY, self.PS_IF_CLOSE, self.ALS_IF_H, self.ALS_IF_L]
         new_interrupt_state = self.interrupt_state
-        print("New int state: %s"%bin(new_interrupt_state))
         for interrupt in interrupts:
             new_state = (new_interrupt_state & (1 << interrupt) > 0)
-            print("Offset %d    new state: %s"%(interrupt, new_state))
-            print("Offset %d cached state: %s"%(interrupt, self.cached_interrupt_state[interrupt]))
             if new_state:
                 self.cached_interrupt_state[interrupt] = new_state
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = ["adafruit_register.i2c_struct", "adafruit_register.i2c_bits",
-                        "adafruit_register.i2c_bit"]
+                        "adafruit_register.i2c_bit", "micropython", "adafruit_bus_device", "adafruit_register"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'BusDevice': ('https://circuitpython.readthedocs.io/projects/busdevice/en/latest/', None),'Register': ('https://circuitpython.readthedocs.io/projects/register/en/latest/', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}


### PR DESCRIPTION
The big change here is how the interrupts are being handled. I added `cached_interrupt_state`, `_update_interrupt_state`, and `_get_and_clear_cached_interrupt_state` to handle saving the interrupt state and modified the properties used to poll the interrupt state to use the cached copy.

This allows any interrupt status check to make sure it has the current interrupt status while not wiping out the state of other interrupts that haven't been polled yet.